### PR TITLE
Include LICENSE file in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Including the license file in the tarball allows users to check under which license the code is published. BSD in setup.py without the LICENSE file could refer to [any of the BSD licenses](https://en.wikipedia.org/wiki/BSD_licenses).

Ref #5