### PR TITLE
Add get method to AttributeManagers

### DIFF
--- a/loompy/attribute_manager.py
+++ b/loompy/attribute_manager.py
@@ -168,3 +168,20 @@ class AttributeManager:
 		"""
 		for key in self.keys():
 			self[key] = self[key][ordering]
+
+	def get(self, name: str, default: np.ndarray):
+		"""
+		Return the value for a named attribute if it exists, else default.
+		Default has to be a numpy array of correct size.
+		"""
+
+		if name in self:
+			return self[name]
+		else:
+			if not isinstance(default, np.ndarray):
+				raise ValueError(f"Default must be an np.ndarray with exactly {self.ds.shape[self.axis]} values")
+
+			if default.shape[0] != self.ds.shape[self.axis]:
+				raise ValueError(f"Default must be an np.ndarray with exactly {self.ds.shape[self.axis]} values but {len(default)} were given")
+
+			return default

--- a/loompy/file_attribute_manager.py
+++ b/loompy/file_attribute_manager.py
@@ -72,3 +72,13 @@ class FileAttributeManager(object):
 			if self.f is not None:
 				del self.f.attrs[name]
 			del self.__dict__["storage"][name]
+
+	def get(self, name: str, default: Any = None):
+		"""
+		Return the value for a named attribute if it exists, else default.
+		If default is not given, it defaults to None, so that this method never raises a KeyError.
+		"""
+		if name in self:
+			return self[name]
+		else:
+			return default

--- a/loompy/tests/test_attribute_manager.py
+++ b/loompy/tests/test_attribute_manager.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+
+import numpy as np
+
+from loompy import AttributeManager
+
+
+class AttributeManagerTests(TestCase):
+	def setUp(self):
+		self.ds = self.DummyLoomConnection()
+
+	def test_get(self):
+		m = AttributeManager(self.ds, axis=0)
+		default = np.array([2., 3, 4, 5, 6, 7, 8])
+
+		# should return value for attribute in file
+		val = m.get("arr", default)
+		np.testing.assert_array_equal(
+			val, np.array([1., 2, 3, 4, 5, 6, 7])
+		)
+
+		# should return default for missing attribute
+		val = m.get("missing", default)
+		np.testing.assert_array_equal(val, default)
+
+	def test_get_raises_on_invalid_default_value(self):
+		m = AttributeManager(self.ds, axis=0)
+
+		# wrong type
+		with self.assertRaises(ValueError):
+			m.get("missing", None)
+
+		# wrong size
+		with self.assertRaises(ValueError):
+			m.get("missing", np.array([1., 2, 3, 4, 5]))
+
+		m = AttributeManager(self.ds, axis=1)
+		with self.assertRaises(ValueError):
+			m.get("missing", np.array([1., 2, 3, 4, 5, 6, 7]))
+
+	class DummyLoomConnection:
+		shape = (7, 5)
+		_file = {
+			"/row_attrs/": {
+				"arr": np.array([1., 2, 3, 4, 5, 6, 7])
+			},
+			"/col_attrs/": {
+				"arr": np.array([1., 2, 3, 4, 5])
+			}
+		}

--- a/loompy/tests/test_file_attribute_manager.py
+++ b/loompy/tests/test_file_attribute_manager.py
@@ -1,0 +1,39 @@
+import os
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+import h5py
+import numpy as np
+
+from loompy import FileAttributeManager
+
+
+class FileAttributeManagerTests(TestCase):
+	VALUE_IN_FILE = np.arange(3)
+
+	def setUp(self):
+		f = NamedTemporaryFile(suffix="loom")
+		f.close()
+		self.filename = f.name
+		self.file = h5py.File(f.name)
+		self.file.attrs["arr"] = self.VALUE_IN_FILE
+
+	def tearDown(self):
+		self.file.close()
+		os.remove(self.filename)
+
+	def test_get(self):
+		m = FileAttributeManager(self.file)
+		default = np.arange(2, 5)
+
+		val = m.get("arr")
+		np.testing.assert_array_equal(val, self.VALUE_IN_FILE)
+
+		val = m.get("arr", default)
+		np.testing.assert_array_equal(val, self.VALUE_IN_FILE)
+
+		val = m.get("missing")
+		self.assertIsNone(val)
+
+		val = m.get("missing", default)
+		np.testing.assert_array_equal(val, default)


### PR DESCRIPTION
As discussed in #53

I have added get method to both AttributeManager and FileAttributeManager. Suggested checks were added only to the AttributeManager's method.

As I could not find any existing tests, I put the new ones in the tests folder. If they should be moved somewhere else/removed, let me know and I will update the pull request.