### PR TITLE
LoomConnection: speedup scan when using default ordering

### DIFF
--- a/loompy/loompy.py
+++ b/loompy/loompy.py
@@ -566,13 +566,14 @@ class LoomConnection:
 		if (items is not None) and (np.issubdtype(items.dtype, np.bool_)):
 			items = np.where(items)[0]
 
-		ordering: np.ndarray = None
+		ordering: Union[np.ndarray, slice] = None
 		vals: Dict[str, loompy.MemoryLoomLayer] = {}
 		if axis == 1:
 			if key is not None:
 				ordering = np.argsort(self.ra[key])
 			else:
-				ordering = np.arange(self.shape[0])
+				# keep everything in original order
+				ordering = slice(None)
 			if items is None:
 				items = np.fromiter(range(self.shape[1]), dtype='int')
 			cols_per_chunk = batch_size
@@ -602,7 +603,8 @@ class LoomConnection:
 			if key is not None:
 				ordering = np.argsort(self.ca[key])
 			else:
-				ordering = np.arange(self.shape[1])
+				# keep everything in original order
+				ordering = slice(None)
 			if items is None:
 				items = np.fromiter(range(self.shape[0]), dtype='int')
 			rows_per_chunk = batch_size

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,36 @@
+import os
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+import numpy as np
+import loompy
+
+
+class LoomConnectionTests(TestCase):
+    def setUp(self) -> None:
+        self.file = NamedTemporaryFile(suffix=".loom")
+        self.file.close()
+        loompy.create(
+            self.file.name,
+            np.random.random((5, 5)),
+            row_attrs={
+                "key": np.fromiter(range(5), dtype=np.int)
+            },
+            col_attrs={
+                "key": np.fromiter(range(5), dtype=np.int)
+            })
+
+    def tearDown(self) -> None:
+        os.remove(self.file.name)
+
+    def test_scan_with_default_ordering(self) -> None:
+        with loompy.connect(self.file.name) as ds:
+            for axis in [0, 1]:
+                _, _, view = next(iter(ds.scan(axis=axis)))
+                no_ordering_data = view[:, :]
+
+                _, _, view = next(iter(ds.scan(axis=axis, key="key")))
+                original_ordering_data = view[:, :]
+
+        np.testing.assert_almost_equal(no_ordering_data, original_ordering_data,
+                                       err_msg="Default ordering should same as in file")


### PR DESCRIPTION
Use a slice instead of array of indices to specify default ordering. This allows numpy to return a view of the original array, otherwise it returns a copy.

gh-89

Same trick could be applied to selection, but would require more changes to the code and does not provide much speedup when axis=0.

Attachment 1: Speed comparison of numpy indexing
```
In [1]: a = np.random.random((10000, 10000))

In [2]: %timeit b = a[:, :]                                                                                                                                                 
266 ns ± 7.33 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [3]: %timeit b = a[:, np.fromiter(range(a.shape[1]), dtype=np.int)]                                                                                                      
1.3 s ± 13.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit b = a[np.fromiter(range(a.shape[1]), dtype=np.int), :]                                                                                                      
476 ms ± 6.31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)                                                                                                                
```